### PR TITLE
ci: update github actions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Deploy update
         uses: RickyRomero/shut-up-amo@main
         env:
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Deploy update
         uses: RickyRomero/shut-up-cws@main
         env:
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Deploy update
         uses: RickyRomero/shut-up-mpc@main
         env:


### PR DESCRIPTION
This PR bumps GitHub Actions to their latest major versions, which now use Node 16 internally instead of Node 12 (EOL as of end of April 2022, no longer receives security updates):

- Changelog for `actions/checkout` can be [found here](https://github.com/actions/checkout/blob/main/CHANGELOG.md)